### PR TITLE
Add baseline model (no uq)

### DIFF
--- a/examples/bo_driven/bo.py
+++ b/examples/bo_driven/bo.py
@@ -6,7 +6,7 @@ import time
 import sys
 from nnueehcs.model_builder import (EnsembleModelBuilder, KDEModelBuilder, 
                                     KNNKDEModelBuilder, DeltaUQMLPModelBuilder, 
-                                    PAGERModelBuilder, MCDropoutModelBuilder)
+                                    PAGERModelBuilder, MCDropoutModelBuilder, BaselineModelBuilder)
 from nnueehcs.training import Trainer, ModelSavingCallback
 from nnueehcs.data_utils import get_dataset, prepare_dataset_for_use
 from nnueehcs.evaluation import get_uncertainty_evaluator, UncertaintyEstimate
@@ -188,6 +188,8 @@ def get_model_builder_class(uq_method):
         return PAGERModelBuilder
     elif uq_method == 'mc_dropout':
         return MCDropoutModelBuilder
+    elif uq_method == 'no_uq':
+        return BaselineModelBuilder
     else:
         raise ValueError(f'Unknown uq method {uq_method}')
 
@@ -506,7 +508,7 @@ def main(benchmark, uq_method, config, dataset, output, restart):
         if successful_trials == bo_config['trials']:
             break
 
-    if len(bo_params.tracking_metric_names) > 1:
+    if successful_trials > 1 and len(bo_params.tracking_metric_names) > 1:
         pareto_results = ax_client.get_pareto_optimal_parameters(use_model_predictions=False)
         pareto_predictions = ax_client.get_pareto_optimal_parameters(use_model_predictions=True)
         pareto = {'results': pareto_results, 'predictions': pareto_predictions}

--- a/nnueehcs/model_builder.py
+++ b/nnueehcs/model_builder.py
@@ -2,7 +2,7 @@ import torch.nn
 import collections
 import io
 import yaml
-from .models import MLPModel, KDEMLPModel, DeltaUQMLP, EnsembleModel, PAGERMLP, MCDropoutModel, KNNKDEMLPModel
+from .models import MLPModel, KDEMLPModel, DeltaUQMLP, EnsembleModel, PAGERMLP, MCDropoutModel, KNNKDEMLPModel, BaselineModel
 import copy
 import types
 
@@ -155,6 +155,20 @@ class MLPModelBuilder(ModelBuilder):
     def build(self):
         model = super().build()
         return MLPModel(model, train_config=self.train_config)
+
+
+class BaselineModelBuilder(ModelBuilder):
+    """Builder for BaselineModel - trains a normal network but returns dummy uncertainty values."""
+    
+    def __init__(self, model_descr, baseline_descr=None, **kwargs):
+        super().__init__(model_descr, **kwargs)
+        self.baseline_descr = baseline_descr or {}
+
+    def build(self):
+        model = super().build()
+        return BaselineModel(model, 
+                           train_config=self.train_config,
+                           **self.baseline_descr)
 
 
 class DeltaUQMLPModelBuilder(ModelBuilder):

--- a/nnueehcs/models.py
+++ b/nnueehcs/models.py
@@ -188,6 +188,43 @@ class MLPModel(WrappedModelBase):
         return self.model(x)
 
 
+class BaselineModel(WrappedModelBase):
+    """Baseline/dummy UE method that trains a normal network but returns dummy uncertainty values.
+    
+    This serves as a baseline for comparison with actual UE methods. It trains a standard neural
+    network and returns dummy uncertainty estimates when requested, allowing it to be used with
+    the same evaluation infrastructure as real UE methods.
+    """
+    def __init__(self, model, uncertainty_value=1.0, **kwargs):
+        """
+        Args:
+            model: The base neural network
+            uncertainty_value: Constant value to return as uncertainty estimate (default: 1.0)
+        """
+        super(BaselineModel, self).__init__(**kwargs)
+        self.model = model
+        self.uncertainty_value = uncertainty_value
+
+    def forward(self, x, return_ue=False):
+        """Forward pass through the model.
+        
+        Args:
+            x: Input tensor
+            return_ue: If True, return (predictions, dummy_uncertainty), else just predictions
+            
+        Returns:
+            If return_ue=False: predictions tensor
+            If return_ue=True: (predictions, dummy_uncertainty_tensor)
+        """
+        predictions = self.model(x)
+        
+        if return_ue:
+            # Return dummy uncertainty values - same shape as predictions but constant value
+            uncertainty = torch.full_like(predictions, self.uncertainty_value)
+            return predictions, uncertainty
+        
+        return predictions
+
 class KDEMLPModel(MLPModel):
     def __init__(self, base_model, bandwidth='scott', rtol=0.1, train_fit_prop=1.0, **kwargs):
         super(KDEMLPModel, self).__init__(base_model, **kwargs)


### PR DESCRIPTION
Adds a baseline uncertainty estimation method that trains a standard neural network but returns dummy uncertainty estimates. This provides a performance baseline for comparing training time and throughput against actual UE methods.

```yaml
uq_methods:
   no_uq:
     parameter_space: []
     uncertainty_value: 1.0  # Optional: constant value for dummy uncertainties
```

Use exactly like any other UE method by specifying uq_method: no_uq in configuration. The method trains normally but returns constant uncertainty values when return_ue=True is called, making it fully compatible with existing evaluation infrastructure while providing baseline performance metrics.